### PR TITLE
Fixed Cobalt and Ardite not being handled correctly by the ExNihilo H…

### DIFF
--- a/src/main/java/ganymedes01/aobd/recipes/modules/ExNihilo.java
+++ b/src/main/java/ganymedes01/aobd/recipes/modules/ExNihilo.java
@@ -15,7 +15,7 @@ import net.minecraftforge.oredict.ShapedOreRecipe;
 public class ExNihilo extends RecipesModule {
 
 	public ExNihilo() {
-		super(CompatType.EX_NIHILO, "iron", "gold", "copper", "tin", "lead", "silver", "nickel", "platinum", "aluminum", "osmium");
+		super(CompatType.EX_NIHILO, "iron", "gold", "copper", "tin", "lead", "silver", "nickel", "platinum", "aluminum", "osmium", "cobalt", "ardite", "mithril");
 	}
 
 	@Override


### PR DESCRIPTION
...andler. Also added Mithril/Manasteel to the list because it is not generated as an ore and therefore should not be added to ExNihilo.
